### PR TITLE
Fix Discount Fortress to prevent flag glitches & Add iron leggings to itemremove

### DIFF
--- a/discount_fortress/map.xml
+++ b/discount_fortress/map.xml
@@ -1,7 +1,7 @@
 <map proto="1.4.0">
 <time overtime="1m" max-overtime="15m">12m</time>
 <name>Discount Fortress</name>
-<version>1.1.1</version>
+<version>1.1.2</version>
 <objective>Capture the enemy team's flag.</objective>
 <gamemode>ctf</gamemode>
 <authors>
@@ -68,7 +68,7 @@
         </regions>
     </default>
 </spawns>
-<flags drop-kit="flagreset" flag-proximity-metric="none">
+<flags flag-proximity-metric="none">
     <flag id="red-flag" name="Red Flag" owner="red-team">
         <post recover-time="20s" respawn-time="15s" pickup-filter="only-blue">14.5,10,-429.5</post>
     </flag>
@@ -91,6 +91,8 @@
         <material>leaves</material>
         <material>glass</material>
     </any>
+    <carrying-flag id="red-flag-carrier">red-flag</carrying-flag>
+    <carrying-flag id="blue-flag-carrier">blue-flag</carrying-flag>
 </filters>
 <regions>
     <union id="flags-region">
@@ -113,12 +115,15 @@
     <apply block="never" region="spawns" message="You may not modify spawn!"/>
     <apply block="can-break" region="playable-region" message="You may only place or break leaves and glass!"/>
     <apply block="never" region="void"/>
+    <apply kit="flagreset" filter="red-flag-carrier" region="blue-flag-region"/>
+    <apply kit="flagreset" filter="blue-flag-carrier" region="red-flag-region"/>
 </regions>
 <toolrepair>
     <tool>stone sword</tool>
     <tool>bow</tool>
 </toolrepair>
 <itemremove>
+    <item>iron leggings</item>
     <item>shears</item>
     <item>sapling</item>
     <item>leaves</item>


### PR DESCRIPTION
Now, only flag-captured player get instant regeneration.